### PR TITLE
Stylistic-, grammar-, and validation-oriented changes

### DIFF
--- a/static/todo-api/index.html
+++ b/static/todo-api/index.html
@@ -9,7 +9,7 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
         crossorigin="anonymous">
-    
+
     <!-- Custom CSS -->
     <link rel="stylesheet" href="styles.css" type="text/css">
 
@@ -17,15 +17,24 @@
 </head>
 
 <body>
-<div class="container">
-    <h1>CSE 204A - ToDo API</h1>
-    <p>This page provides documentaion for using the ToDo API for CSE 204A. This API allows you to list, get, create, update, and delete ToDo items via a REST API interface. This API is hosted in AWS and you can view the source code on GitHub here: <a href="https://github.com/kraigh/serverless-todo-api">https://github.com/kraigh/serverless-todo-api</a></p>
-    <h2>API Key</h2>
-    <p>Generate an API key here: <a href="https://cse204.kraigh.net/api-key">https://cse204.kraigh.net/api-key</a>.</p>
-    <p>This API key is used to reference all data associated with your user. Note: it is essentially a password that authorizes API calls to access your data, so keep it private!</p>
-    <p>The API key must be sent with every request to the API and is sent via a header with a key of <code>x-api-key</code></p>
-    <h2>ToDo Data Object</h2>
-    <p>Each ToDo is stored in the database with a number of fields. Some can be modified, and some are set automatically. See the table below for an explanation of the properties in each <code>todo</code> object</p>
+    <div class="container">
+        <h1>CSE 204A - ToDo API</h1>
+        <p>This page provides documentaion for using the ToDo API for CSE 204A. This API allows you to list, get, create, update,
+            and delete ToDo items via a REST API interface. This API is hosted in AWS and you can view the source code on
+            GitHub
+            <a href="https://github.com/kraigh/serverless-todo-api">here</a>.</p>
+        <h2>API Key</h2>
+        <p>Generate an API key
+            <a href="https://cse204.kraigh.net/api-key">here</a>.</p>
+        <p>This API key is used to reference all data associated with your user. Note: It is essentially a password that authorizes
+            API calls to access your data; so, keep it private!</p>
+        <p>The API key must be sent with every request to the API and is sent via a header with a key of
+            <code>x-api-key</code>.
+        </p>
+        <h2>ToDo Data Object</h2>
+        <p>Each ToDo is stored in the database with a number of fields. Some can be modified, and some are set automatically.
+            See the table below for an explanation of the properties in each
+            <code>todo</code> object.</p>
         <table class="table">
             <thead>
                 <tr class="d-flex">
@@ -41,7 +50,9 @@
                     <td class="col-2">
                         <code>text</code>
                     </td>
-                    <td class="col-1"><pre>string</pre></td>
+                    <td class="col-1">
+                        <pre>string</pre>
+                    </td>
                     <td class="col-2 text-primary">Buy Groceries</td>
                     <td class="col-3">Set by user in POST request</td>
                     <td class="col-4">The main text of the ToDo</td>
@@ -54,7 +65,7 @@
                         <pre>string</pre>
                     </td>
                     <td class="col-2 text-primary">0ef61ae0-dc34-11e8-bd4d-71a1c19eb6c3</td>
-                    <td class="col-3">Automatically Generated</td>
+                    <td class="col-3">Automatically generated</td>
                     <td class="col-3">Unique ID of the ToDo. Used when making updates or deleting.</td>
                 </tr>
                 <tr class="d-flex">
@@ -66,7 +77,8 @@
                     </td>
                     <td class="col-2 text-primary">false</td>
                     <td class="col-3">Defaults to false</td>
-                    <td class="col-4">Whether or not the ToDo has been completed. Needs to be manually updated to <code>true</code>.</td>
+                    <td class="col-4">Whether the ToDo has been completed. Needs to be manually updated to
+                        <code>true</code>.</td>
                 </tr>
                 <tr class="d-flex">
                     <td class="col-2">
@@ -76,7 +88,7 @@
                         <pre>number</pre>
                     </td>
                     <td class="col-2 text-primary">1540897678</td>
-                    <td class="col-3">Set when ToDo is created.</td>
+                    <td class="col-3">Set when ToDo is created</td>
                     <td class="col-4">Unix timestamp representing time when ToDo was created. Can be used to sort.</td>
                 </tr>
                 <tr class="d-flex">
@@ -87,7 +99,7 @@
                         <pre>number</pre>
                     </td>
                     <td class="col-2 text-primary">1540897798</td>
-                    <td class="col-3">Set when ToDo is modified.</td>
+                    <td class="col-3">Set when ToDo is modified</td>
                     <td class="col-4">Unix timestamp representing time when ToDo was modified. Can be used to sort.</td>
                 </tr>
                 <tr class="d-flex">
@@ -98,36 +110,41 @@
                         <pre>string</pre>
                     </td>
                     <td class="col-2 text-primary">38c5439331dbc7e...</td>
-                    <td class="col-3">User API Key.</td>
+                    <td class="col-3">User API Key</td>
                     <td class="col-4">Unique ID representing a specific user who the ToDo belongs to.</td>
                 </tr>
             </tbody>
         </table>
-    <h2>API Methods</h2>
-    <p>The ToDo API endpoints accept JSON formatted data in the request body where indicated. All endpoints return JSON data in the response body.</p>
-    <table class="table">
-        <thead>
-            <tr class="d-flex">
-                <th class="col-4">Endpoint URL</th>
-                <th class="col-1">Method</th>
-                <th class="col-3">JSON Request Body</th>
-                <th class="col-4">JSON Response Body</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr class="d-flex">
-                <td class="col-4">
-                    <code>https://api.kraigh.net/todos</code>
-                    <p class="text-muted"><strong>List ToDos:</strong> This endpoint returns an array of all ToDos for the provided user. <a href="#list-info">More Info</a></p>
-                </td>
-                <td class="col-1"><code>GET</code></td>
-                <td class="col-3">(none)</td>
-                <td class="col-4">
-                    <a class="" data-toggle="collapse" href="#list-response" aria-expanded="false"
-                        aria-controls="list-response">
-                        Show Example Response
-                    </a>
-                    <pre class="text-info bg-light p-3 collapse" id="list-response">
+        <h2>API Methods</h2>
+        <p>The ToDo API endpoints accept JSON formatted data in the request body where indicated. All endpoints return JSON
+            data in the response body.</p>
+        <table class="table">
+            <thead>
+                <tr class="d-flex">
+                    <th class="col-4">Endpoint URL</th>
+                    <th class="col-1">Method</th>
+                    <th class="col-3">JSON Request Body</th>
+                    <th class="col-4">JSON Response Body</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr class="d-flex">
+                    <td class="col-4">
+                        <code>https://api.kraigh.net/todos</code>
+                        <p class="text-muted">
+                            <strong>List ToDos:</strong> This endpoint returns an array of all ToDos for the provided user.
+                            <a href="#list-info">More Info</a>
+                        </p>
+                    </td>
+                    <td class="col-1">
+                        <code>GET</code>
+                    </td>
+                    <td class="col-3">(none)</td>
+                    <td class="col-4">
+                        <a class="" data-toggle="collapse" href="#list-response" aria-expanded="false" aria-controls="list-response">
+                            Show Example Response
+                        </a>
+                        <pre class="text-info bg-light p-3 collapse" id="list-response">
 [
     {
         "completed": false,
@@ -141,67 +158,96 @@
         "text": "Another thing",
         "id": "50d8cd20-da29"
     }
-]</pre></td>
-            </tr>
-            <tr class="d-flex">
-                <td class="col-4">
-                    <code>https://api.kraigh.net/todos</code>
-                    <p class="text-muted"><strong>Create A ToDo:</strong> Sending data via a <code>POST</code> request to this endpoint will create a new ToDo. The full ToDo item will be returned, including a programmatically generated ID. <a href="#create-info">More Info</a></p>
-                </td>
-                <td class="col-1"><code>POST</code></td>
-                <td class="col-3"><pre class="text-info bg-light p-3">
+]</pre>
+                    </td>
+                </tr>
+                <tr class="d-flex">
+                    <td class="col-4">
+                        <code>https://api.kraigh.net/todos</code>
+                        <p class="text-muted">
+                            <strong>Create A ToDo:</strong> Sending data via a
+                            <code>POST</code> request to this endpoint will create a new ToDo. The full ToDo item will be returned, including
+                            a programmatically generated ID.
+                            <a href="#create-info">More Info</a>
+                        </p>
+                    </td>
+                    <td class="col-1">
+                        <code>POST</code>
+                    </td>
+                    <td class="col-3">
+                        <pre class="text-info bg-light p-3">
 {
 "text": "Another new thing"
-}</pre></td>
-                <td class="col-4">
-                    <a class="" data-toggle="collapse" href="#create-response" aria-expanded="false" aria-controls="list-response">
-                        Show Example Response
-                    </a>
-                    <pre class="text-info bg-light p-3 collapse" id="create-response">
+}</pre>
+                    </td>
+                    <td class="col-4">
+                        <a class="" data-toggle="collapse" href="#create-response" aria-expanded="false" aria-controls="list-response">
+                            Show Example Response
+                        </a>
+                        <pre class="text-info bg-light p-3 collapse" id="create-response">
 {
     "user": "&lt;your api key&gt;",
     "id": "3a3d6a40-da37",
     "text": "Another new thing",
     "completed": false
 }</pre>
-                </td>
-            </tr>
-            <tr class="d-flex">
-                <td class="col-4">
-                    <code>https://api.kraigh.net/todos/{id}</code>
-                    <p class="text-muted"><strong>Get A ToDo:</strong> Sending a <code>GET</code> request to this endpoint with a valid <code>id</code> for an existing ToDo will return that ToDo. <a href="#get-info">More Info</a></p>
-                </td>
-                <td class="col-1"><code>GET</code></td>
-                <td class="col-3">(none)</td>
-                <td class="col-4">
-                    <a class="" data-toggle="collapse" href="#get-response" aria-expanded="false" aria-controls="list-response">
-                        Show Example Response
-                    </a>
-                    <pre class="text-info bg-light p-3 collapse" id="get-response">
+                    </td>
+                </tr>
+                <tr class="d-flex">
+                    <td class="col-4">
+                        <code>https://api.kraigh.net/todos/{id}</code>
+                        <p class="text-muted">
+                            <strong>Get A ToDo:</strong> Sending a
+                            <code>GET</code> request to this endpoint with a valid
+                            <code>id</code> for an existing ToDo will return that ToDo.
+                            <a href="#get-info">More Info</a>
+                        </p>
+                    </td>
+                    <td class="col-1">
+                        <code>GET</code>
+                    </td>
+                    <td class="col-3">(none)</td>
+                    <td class="col-4">
+                        <a class="" data-toggle="collapse" href="#get-response" aria-expanded="false" aria-controls="list-response">
+                            Show Example Response
+                        </a>
+                        <pre class="text-info bg-light p-3 collapse" id="get-response">
 {
     "completed": false,
     "user": "&lt;your api key&gt;",
     "text": "Another new thing",
     "id": "3a3d6a40-da37"
 }</pre>
-                </td>
-            </tr>
-            <tr class="d-flex">
-                <td class="col-4">
-                    <code>https://api.kraigh.net/todos/{id}</code>
-                    <p class="text-muted"><strong>Update A ToDo:</strong> A <code>PUT</code> request to this endpoint with a valid <code>id</code> in the URL will allow you to update one or more properties of the ToDo. Only the properties <code>completed</code> (boolean) and <code>text</code> (string) passed in the JSON object will be updated. The full updated object will be returned in the JSON body. <a href="#update-info">More Info</a></p>
-                </td>
-                <td class="col-1"><code>PUT</code></td>
-                <td class="col-3"><pre class="text-info bg-light p-3">
+                    </td>
+                </tr>
+                <tr class="d-flex">
+                    <td class="col-4">
+                        <code>https://api.kraigh.net/todos/{id}</code>
+                        <p class="text-muted">
+                            <strong>Update A ToDo:</strong> A
+                            <code>PUT</code> request to this endpoint with a valid
+                            <code>id</code> in the URL will allow you to update one or more properties of the ToDo. Only the properties
+                            <code>completed</code> (boolean) and
+                            <code>text</code> (string) passed in the JSON object will be updated. The full updated object will be returned
+                            in the JSON body.
+                            <a href="#update-info">More Info</a>
+                        </p>
+                    </td>
+                    <td class="col-1">
+                        <code>PUT</code>
+                    </td>
+                    <td class="col-3">
+                        <pre class="text-info bg-light p-3">
 {
     "completed": true
 }
-                </pre></td>
-                <td class="col-4">
-                    <a class="" data-toggle="collapse" href="#update-response" aria-expanded="false" aria-controls="list-response">
-                        Show Example Response
-                    </a>
-                    <pre class="text-info bg-light p-3 collapse" id="update-response">
+                </pre>
+                    </td>
+                    <td class="col-4">
+                        <a class="" data-toggle="collapse" href="#update-response" aria-expanded="false" aria-controls="list-response">
+                            Show Example Response
+                        </a>
+                        <pre class="text-info bg-light p-3 collapse" id="update-response">
 {
     "completed": true,
     "user": "&lt;your api key&gt;",
@@ -209,47 +255,55 @@
     "id": "50d8cd20-da29"
 }
 </pre>
-                </td>
-            </tr>
-            <tr class="d-flex">
-                <td class="col-4">
-                    <code>https://api.kraigh.net/todos/{id}</code>
-                    <p class="text-muted"><strong>Delete A ToDo:</strong> A <code>DELETE</code> request to this endpoint with a valid ToDo <code>id</code> in the URL will delete the ToDo with that id. An empty JSON object is returned, with a <code>200</code> status if deletion was successful, or a <code>404</code> status if that ToDo does not exist.</code> <a href="#delete-info">More Info</a></p>
-                </td>
-                <td class="col-1"><code>DELETE</code></td>
-                <td class="col-3">(none)</td>
-                <td class="col-4">(none)</td>
-            </tr>
-        </tbody>
-    </table>
-    <section id="list-info">
-        <h3>LIST All ToDos</h3>
-        <p>When your page loads, you want to make an AJAX request to get all existing
-            ToDos tied to your API key, so you can add those ToDos
-            to your HTML. Do this by making a GET AJAX request to this URL:</p>
-        <pre class="text-info bg-light p-3">https://api.kraigh.net/todos</pre>
-        <p>Note: you need send your API key as an <code>x-api-key</code> header. This is done using the <code>setRequestHeader</code> method:</p>
-        <pre class="text-info bg-light p-3">xhttp.setRequestHeader(&quot;x-api-key&quot;, &quot;abc123&quot;);</pre>
-        <p>This AJAX request will return an array of objects as JSON. Each object will be
-            a ToDo that has been previously submitted with your API key. To pare this JSON into a usable array, use <code>JSON.parse()</code>:</p>
-        <pre class="text-info bg-light p-3">var todos = JSON.parse(this.responseText);</pre>
-        <p></p>Note:
-            Before you have successfully submitted any ToDos, this array
-            will be empty.</p>
-        <div class="accordion" id="listExample">
-            <div class="card">
-                <div class="card-header" id="listJavascriptHeading">
-                    <h5 class="mb-0">
-                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#listJavascript"
-                            aria-expanded="true" aria-controls="listJavascript">
-                            Javascript Example +
-                        </button>
-                    </h5>
-                </div>
+                    </td>
+                </tr>
+                <tr class="d-flex">
+                    <td class="col-4">
+                        <code>https://api.kraigh.net/todos/{id}</code>
+                        <p class="text-muted">
+                            <strong>Delete A ToDo:</strong> A
+                            <code>DELETE</code> request to this endpoint with a valid ToDo
+                            <code>id</code> in the URL will delete the ToDo with that id. An empty JSON object is returned, with a
+                            <code>200</code> status if deletion was successful, or a
+                            <code>404</code> status if that ToDo does not exist.
+                            <a href="#delete-info">More Info</a>
+                        </p>
+                    </td>
+                    <td class="col-1">
+                        <code>DELETE</code>
+                    </td>
+                    <td class="col-3">(none)</td>
+                    <td class="col-4">(none)</td>
+                </tr>
+            </tbody>
+        </table>
+        <section id="list-info">
+            <h3>LIST All ToDos</h3>
+            <p>On page load, your webpage will need to render all existing ToDos tied to your API key. To add the data to your
+                HTML, make a GET AJAX request to this URL:</p>
+            <pre class="text-info bg-light p-3">https://api.kraigh.net/todos</pre>
+            <p>Note: The API key must be sent as an
+                <code>x-api-key</code> header. This is done using the
+                <code>setRequestHeader</code> method:</p>
+            <pre class="text-info bg-light p-3">xhttp.setRequestHeader(&quot;x-api-key&quot;, &quot;abc123&quot;);</pre>
+            <p>This AJAX request will return an array of objects as JSON. Each object will be a ToDo that has been previously
+                submitted with your API key. To parse this JSON into a usable array, use
+                <code>JSON.parse()</code>:</p>
+            <pre class="text-info bg-light p-3">var todos = JSON.parse(this.responseText);</pre>
+            <p>Note: Before you have successfully submitted any ToDos, this array will be empty.</p>
+            <div class="accordion" id="listExample">
+                <div class="card">
+                    <div class="card-header" id="listJavascriptHeading">
+                        <h5 class="mb-0">
+                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#listJavascript" aria-expanded="true" aria-controls="listJavascript">
+                                JavaScript Example +
+                            </button>
+                        </h5>
+                    </div>
 
-                <div id="listJavascript" class="collapse" aria-labelledby="listJavascriptHeading" data-parent="#listExample">
-                    <div class="card-body bg-light p-3">
-        <pre class="text-info">
+                    <div id="listJavascript" class="collapse" aria-labelledby="listJavascriptHeading" data-parent="#listExample">
+                        <div class="card-body bg-light p-3">
+                            <pre class="text-info">
 var xhttp = new XMLHttpRequest();
 
 xhttp.onreadystatechange = function() {
@@ -262,41 +316,41 @@ xhttp.onreadystatechange = function() {
 xhttp.open(&quot;GET&quot;, &quot;https://api.kraigh.net/todos, true);
 xhttp.setRequestHeader("x-api-key","abc123");
 xhttp.send();</pre>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
-    <section id="create-info">
-        <h3>POST New ToDos</h3>
-        <p>When your new ToDo form is submitted, you want to trigger a Javascript
-            event that will make an AJAX call to submit your new ToDo to
-            the server, and if saving it is successful, add your new ToDo
-            to the page&apos;s HTML. Do this by making an AJAX POST request to this
-            URL:</p>
-        <pre class="text-info bg-light p-3">https://api.kraigh.net/todos</pre>
-        <p>Your POST will need the following parameters, encoded as JSON:</p>
-        <dl><dt>text</dt>
-            <dd>The text of the to-do item</dd>
-        </dl>
-        <p>If unsuccessful, this POST request will return a text error. If successful,
-            it will return a single object containing the ToDo that has been
-            saved. This object will have a <code>text</code>, <code>id</code>, and <code>user</code> property
-            that you can use to add a new HTML element to your existing ToDo.</p>
-        <div class="accordion" id="createExample">
-            <div class="card">
-                <div class="card-header" id="createJavascriptHeading">
-                    <h5 class="mb-0">
-                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#createJavascript"
-                            aria-expanded="true" aria-controls="createJavascript">
-                            Javascript Example +
-                        </button>
-                    </h5>
-                </div>
-        
-                <div id="createJavascript" class="collapse" aria-labelledby="createJavascriptHeading" data-parent="#createExample">
-                    <div class="card-body bg-light p-3">
-                        <pre class="text-info">
+        </section>
+        <section id="create-info">
+            <h3>POST New ToDos</h3>
+            <p>When your new ToDo form is submitted, you want to trigger a JavaScript event that will make an AJAX call to submit
+                your new ToDo to the server, and if saving it is successful, add your new ToDo to the page&apos;s HTML. Do
+                this by making an AJAX POST request to this URL:
+            </p>
+            <pre class="text-info bg-light p-3">https://api.kraigh.net/todos</pre>
+            <p>Your POST will need the following parameters, encoded as JSON:</p>
+            <dl>
+                <dt>text</dt>
+                <dd>The text of the to-do item</dd>
+            </dl>
+            <p>If unsuccessful, this POST request will return a text error. If successful, it will return a single object containing
+                the ToDo that has been saved. This object will have a
+                <code>text</code>,
+                <code>id</code>, and
+                <code>user</code> property that you can use to add a new HTML element to your existing ToDo.</p>
+            <div class="accordion" id="createExample">
+                <div class="card">
+                    <div class="card-header" id="createJavascriptHeading">
+                        <h5 class="mb-0">
+                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#createJavascript" aria-expanded="true" aria-controls="createJavascript">
+                                JavaScript Example +
+                            </button>
+                        </h5>
+                    </div>
+
+                    <div id="createJavascript" class="collapse" aria-labelledby="createJavascriptHeading" data-parent="#createExample">
+                        <div class="card-body bg-light p-3">
+                            <pre class="text-info">
 // Setting variable for form input (get from HTML form)
 var data = {
     text: &quot;Some Text&quot;
@@ -329,33 +383,43 @@ xhttp2.open(&quot;POST&quot;, &quot;https://api.kraigh.net/todos&quot;, true);
 xhttp2.setRequestHeader(&quot;Content-type&quot;, &quot;application/json&quot;);
 xhr.setRequestHeader(&quot;x-api-key&quot;, &quot;abc123&quot;);
 xhttp2.send(JSON.stringify(data));</pre>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
-    <section id="get-info">
-        <h3>GET a ToDo</h3>
-        <p>To retrieve the info for a single ToDo, send a GET request to this URL, with the ToDo's <code>id</code> in place of <code>{id}</code>.</p>
-        <pre class="text-info bg-light p-3">https://api.kraigh.net/todos/{id}</pre>
-        <p>Make sure you include your API Key in the <code>x-api-key</code> header.</p>
-        <p>If unsuccessful, this GET request will return a text error. If successful,
-            it will return a single JSON object containing the ToDo that you requested. This object will have <code>text</code>, <code>id</code>, <code>completed</code>, <code>created</code>, <code>updated</code>, and <code>user</code> properties.</p>
-        <p><strong>Note:</strong> depending on how you structure your application, you may not need to use this endpoint, since the LIST endpoint returns full ToDo objects.</p>
+        </section>
+        <section id="get-info">
+            <h3>GET a ToDo</h3>
+            <p>To retrieve the info for a single ToDo, send a GET request to this URL, with the ToDo's
+                <code>id</code> in place of
+                <code>{id}</code>.</p>
+            <pre class="text-info bg-light p-3">https://api.kraigh.net/todos/{id}</pre>
+            <p>Make sure you include your API Key in the
+                <code>x-api-key</code> header.</p>
+            <p>If unsuccessful, this GET request will return a text error. If successful, it will return a single JSON object
+                containing the ToDo that you requested. This object will have
+                <code>text</code>,
+                <code>id</code>,
+                <code>completed</code>,
+                <code>created</code>,
+                <code>updated</code>, and
+                <code>user</code> properties.</p>
+            <p>
+                <strong>Note:</strong> Depending on how you structure your application, you may not need to use this endpoint, since
+                the LIST endpoint returns full ToDo objects.</p>
             <div class="accordion" id="getExample">
-            <div class="card">
-                <div class="card-header" id="getJavascriptHeading">
-                    <h5 class="mb-0">
-                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#getJavascript"
-                            aria-expanded="true" aria-controls="getJavascript">
-                            Javascript Example +
-                        </button>
-                    </h5>
-                </div>
-        
-                <div id="getJavascript" class="collapse" aria-labelledby="getJavascriptHeading" data-parent="#getExample">
-                    <div class="card-body bg-light p-3">
-                        <pre class="text-info">
+                <div class="card">
+                    <div class="card-header" id="getJavascriptHeading">
+                        <h5 class="mb-0">
+                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#getJavascript" aria-expanded="true" aria-controls="getJavascript">
+                                JavaScript Example +
+                            </button>
+                        </h5>
+                    </div>
+
+                    <div id="getJavascript" class="collapse" aria-labelledby="getJavascriptHeading" data-parent="#getExample">
+                        <div class="card-body bg-light p-3">
+                            <pre class="text-info">
 // Setting variable for ToDo id
 var id = "abcd-1234"
 
@@ -386,32 +450,36 @@ xhttp2.open(&quot;POST&quot;, &quot;https://api.kraigh.net/todos/&quot;+id, true
 xhttp2.setRequestHeader(&quot;Content-type&quot;, &quot;application/json&quot;);
 xhr.setRequestHeader(&quot;x-api-key&quot;, &quot;abc123&quot;);
 xhttp2.send(JSON.stringify(data));</pre>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
-    <section id="update-info">
-        <h3>PUT ToDo Updates</h3>
-        <p>To change the properties of a ToDo, send a PUT request with the data you want to update to this url, with the <code>id</code> of the ToDo you want to update in place of <code>{id}</code></code></p>
-        <pre class="text-info bg-light p-3">https://api.kraigh.net/todos/{id}</pre>
-        <p>You will use this endpoint to change a ToDo's status to &quot;completed&quot; once it has been checked off. Optionally, if you want to allow for editing the text of your ToDos, you can accomplish that by including a new <code>text</code> value in your PUT request to this endpoint.</p>
-        <p>If unsuccessful, this GET request will return a text error. If successful,
-            it will return a <code>200</code> response code and an empty body response.</p>
-        <div class="accordion" id="updateExample">
-            <div class="card">
-                <div class="card-header" id="updateJavascriptHeading">
-                    <h5 class="mb-0">
-                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#updateJavascript"
-                            aria-expanded="true" aria-controls="updateJavascript">
-                            Javascript Example +
-                        </button>
-                    </h5>
-                </div>
-        
-                <div id="updateJavascript" class="collapse" aria-labelledby="updateJavascriptHeading" data-parent="#updateExample">
-                    <div class="card-body bg-light p-3">
-                        <pre class="text-info">
+        </section>
+        <section id="update-info">
+            <h3>PUT ToDo Updates</h3>
+            <p>To change the properties of a ToDo, send a PUT request with the data you want to update to this URL, with the
+                <code>id</code> of the ToDo you want to update in place of
+                <code>{id}</code>.
+            </p>
+            <pre class="text-info bg-light p-3">https://api.kraigh.net/todos/{id}</pre>
+            <p>You will use this endpoint to change a ToDo's status to &quot;completed&quot; once it has been checked off. Optionally,
+                if you want to allow for editing the text of your ToDos, you can accomplish that by including a new
+                <code>text</code> value in your PUT request to this endpoint.</p>
+            <p>If unsuccessful, this GET request will return a text error. If successful, it will return a
+                <code>200</code> response code and an empty body response.</p>
+            <div class="accordion" id="updateExample">
+                <div class="card">
+                    <div class="card-header" id="updateJavascriptHeading">
+                        <h5 class="mb-0">
+                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#updateJavascript" aria-expanded="true" aria-controls="updateJavascript">
+                                JavaScript Example +
+                            </button>
+                        </h5>
+                    </div>
+
+                    <div id="updateJavascript" class="collapse" aria-labelledby="updateJavascriptHeading" data-parent="#updateExample">
+                        <div class="card-body bg-light p-3">
+                            <pre class="text-info">
 // You're on your own for this one!
 
 // Make sure you include a ToDo ID in the URL, you will probably get that ID from the ID field of your ToDo element in HTML inside your click event.
@@ -421,43 +489,44 @@ var data = {
     completed: true
 }
 </pre>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
-    <section id="delete-info">
-        <h3>DELETE a ToDo</h3>
-        <p>To delete a ToDo, send a DELETE request with the data you want to update to this url, with the <code>id</code>
-            of the ToDo you want to update in place of <code>{id}</code></code></p>
-        <pre class="text-info bg-light p-3">https://api.kraigh.net/todos/{id}</pre>
-        <p>If unsuccessful, this GET request will return a text error. If successful,
-            it will return a <code>200</code> response code and an empty body response.</p>
-        <div class="accordion" id="updateExample">
-            <div class="card">
-                <div class="card-header" id="updateJavascriptHeading">
-                    <h5 class="mb-0">
-                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#updateJavascript"
-                            aria-expanded="true" aria-controls="updateJavascript">
-                            Javascript Example +
-                        </button>
-                    </h5>
-                </div>
-        
-                <div id="updateJavascript" class="collapse" aria-labelledby="updateJavascriptHeading" data-parent="#updateExample">
-                    <div class="card-body bg-light p-3">
-                        <pre class="text-info">
+        </section>
+        <section id="delete-info">
+            <h3>DELETE a ToDo</h3>
+            <p>To delete a ToDo, send a DELETE request with the data you want to update to this URL, with the
+                <code>id</code> of the ToDo you want to update in place of
+                <code>{id}</code>.
+            </p>
+            <pre class="text-info bg-light p-3">https://api.kraigh.net/todos/{id}</pre>
+            <p>If unsuccessful, this GET request will return a text error. If successful, it will return a
+                <code>200</code> response code and an empty body response.</p>
+            <div class="accordion" id="updateExample">
+                <div class="card">
+                    <div class="card-header" id="updateJavascriptHeading">
+                        <h5 class="mb-0">
+                            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#updateJavascript" aria-expanded="true" aria-controls="updateJavascript">
+                                JavaScript Example +
+                            </button>
+                        </h5>
+                    </div>
+
+                    <div id="updateJavascript" class="collapse" aria-labelledby="updateJavascriptHeading" data-parent="#updateExample">
+                        <div class="card-body bg-light p-3">
+                            <pre class="text-info">
         // You're on your own for this one!
 
         // Make sure that you set the request method to "DELETE"
         </pre>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
+        </section>
 
-</div>
+    </div>
 
     <!-- Optional JavaScript -->
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
@@ -507,7 +576,7 @@ var data = {
     // xhttp2.setRequestHeader("x-api-key", "abc123");
     // xhttp2.send(JSON.stringify(data));
 
-    
+
     </script>
 </body>
 


### PR DESCRIPTION
* Changes
    * Copy 
        * Inconsistencies in stylization
            * Some elements in table end with period (even though not full sentences), others not
            * Some capitalization where unnecessary (e.g. ‘Generated’)
            * URL lowercase in some instances
            * Some descriptions under the headings are full sentences but don’t end with periods
            * Javascript → JavaScript
        * General, minor fixes
            * ‘pare’ → ‘parse’
            * ’whether or not’ → ‘whether’
            * Word following ‘note’ should be capitalized
            * “When your page loads, you want to make an AJAX request to get all existing ToDos tied to your API key, so you can add those ToDos to your HTML.” (run-on) -> consider breaking up along the lines of “On page load, your webpage will need to render all existing ToDos tied to your API key. To do this, make an AJAX request, adding the data then received to your HTML.”
            * Consider rephrasing sentences in the second person (i.e. those with ‘you’ as the subject) to third person, or use the imperative. For example, “you need send your API key as an x-api-key header.” → “The API key must be sent as an x-api-key header” or “Send your API key as an x-api-key header.”