### PR TITLE
Added return to callbacks

### DIFF
--- a/todos/apiKey.js
+++ b/todos/apiKey.js
@@ -24,9 +24,9 @@ module.exports.create = (event, context, callback) => {
     const userInfo = JSON.parse(event.body);
 
     if (userInfo.email === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or malformed 'email' property in JSON object in request body.") });
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or malformed 'email' property in JSON object in request body.") });
     } else if (userInfo.name === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or malformed 'name' property in JSON object in request body.") });
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or malformed 'name' property in JSON object in request body.") });
     }
 
     var timestamp = moment().valueOf();

--- a/todos/create.js
+++ b/todos/create.js
@@ -21,17 +21,17 @@ module.exports.create = (event, context, callback) => {
     };
 
     const todoItem = JSON.parse(event.body);
-    
+
     if (event.headers["x-api-key"] === undefined) {
-        callback(null, { statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.") });
+        return callback(null, { statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.") });
     } else if (event.headers["x-api-key"].length < 1) {
-        callback(null, { statusCode: 400, body: JSON.stringify("Empty x-api-key header value.") });
+        return callback(null, { statusCode: 400, body: JSON.stringify("Empty x-api-key header value.") });
     } else if (todoItem.text === undefined) {
-        callback(null, { statusCode: 400, body: JSON.stringify("Missing or malformed 'text' property in JSON object in request body.") });
+        return callback(null, { statusCode: 400, body: JSON.stringify("Missing or malformed 'text' property in JSON object in request body.") });
     } else if (todoItem.text.length < 1) {
-        callback(null, { statusCode: 400, body: JSON.stringify("Empty 'text' property in JSON object in request body.") });
+        return callback(null, { statusCode: 400, body: JSON.stringify("Empty 'text' property in JSON object in request body.") });
     }
-    
+
     const timestamp = Math.floor(new Date() / 1000);
     const params = {
         TableName: process.env.TODOS_TABLE,

--- a/todos/delete.js
+++ b/todos/delete.js
@@ -21,11 +21,11 @@ module.exports.delete = (event, context, callback) => {
     };
 
     if (event.headers["x-api-key"] === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.")});
     } else if (event.headers["x-api-key"].length < 1) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Empty x-api-key header value.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Empty x-api-key header value.")});
     } else if (event.pathParameters.id === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing 'id' in URL path.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing 'id' in URL path.")});
     }
 
     const params = {

--- a/todos/get.js
+++ b/todos/get.js
@@ -20,11 +20,11 @@ module.exports.get = (event, context, callback) => {
     };
 
     if (event.headers["x-api-key"] === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.")});
     } else if (event.headers["x-api-key"].length < 1) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Empty x-api-key header value.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Empty x-api-key header value.")});
     } else if (event.pathParameters.id === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing 'id' in URL path.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing 'id' in URL path.")});
     }
 
     const params = {

--- a/todos/list.js
+++ b/todos/list.js
@@ -20,9 +20,9 @@ module.exports.list = (event, context, callback) => {
     };
 
     if (event.headers["x-api-key"] === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.")});
     } else if (event.headers["x-api-key"].length < 1) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Empty x-api-key header value.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Empty x-api-key header value.")});
     }
 
     const params = {

--- a/todos/update.js
+++ b/todos/update.js
@@ -23,11 +23,11 @@ module.exports.update = (event, context, callback) => {
     const todoItem = JSON.parse(event.body);
 
     if (event.headers["x-api-key"] === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing or invalid x-api-key header.")});
     } else if (event.headers["x-api-key"].length < 1) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Empty x-api-key header value.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Empty x-api-key header value.")});
     } else if (event.pathParameters.id === undefined) {
-        callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing 'id' in URL path.")});
+        return callback(null, { headers: headers, statusCode: 400, body: JSON.stringify("Missing 'id' in URL path.")});
     }
 
     const updateNames = {};
@@ -44,7 +44,7 @@ module.exports.update = (event, context, callback) => {
         updateArray.push("#t = :t");
     }
     if (updateArray.length == 0) {
-        callback(null, { statusCode: 400, body: "No properties passed to update. Supports 'completed' and 'text'.", headers: { "Content-Type": "text/plain" } });
+        return callback(null, { statusCode: 400, body: "No properties passed to update. Supports 'completed' and 'text'.", headers: { "Content-Type": "text/plain" } });
     }
     const timestamp = Math.floor(new Date() / 1000);
     updateNames["#u"] = "updated";


### PR DESCRIPTION
This fixes the following warning:

`Serverless: Warning: context.done called twice within handler...`

And prevents unnecessary dynamo calls when the request is not valid.