### PR TITLE
Extra Credit Documentation Fix

### DIFF
--- a/static/todo-api/index.html
+++ b/static/todo-api/index.html
@@ -445,11 +445,11 @@ xhttp2.onreadystatechange = function() {
     }
 };
 
-xhttp2.open(&quot;POST&quot;, &quot;https://api.kraigh.net/todos/&quot;+id, true);
+xhttp2.open(&quot;GET&quot;, &quot;https://api.kraigh.net/todos/&quot;+id, true);
 
 xhttp2.setRequestHeader(&quot;Content-type&quot;, &quot;application/json&quot;);
 xhttp2.setRequestHeader(&quot;x-api-key&quot;, &quot;abc123&quot;);
-xhttp2.send(JSON.stringify(data));</pre>
+xhttp2.send();</pre>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
I found an error in the ToDo API documentation that I want to push. The error is in the Javascript example for the GET a ToDo section: as it currently stands, the code returns an error stating that the data object referenced in the xhttp2.send() method is undefined. Additionally, the xhttp2.open() method has a "POST" parameter which adds to the array of ToDos rather than retrieves the ToDos.

I've made a few fixes in the example code in the documentation to correct these errors:
- deleted the parameter referenced in the xhttp2.send() method
- changed the "POST" parameter to a "GET" parameter in the xhttp2.open() method.